### PR TITLE
Fixed possible issue when exporting images to other apps

### DIFF
--- a/ViewFinderOverlay.qml
+++ b/ViewFinderOverlay.qml
@@ -516,6 +516,7 @@ Item {
 
                     property string settingsProperty: "preferRemovableStorage"
                     property string icon: ""
+                    // TRANSLATORS: this will be displayed on an small button so for it to fit it should be less then 3 characters long.
                     property string label: i18n.tr("SD")
                     property bool isToggle: true
                     property int selectedIndex: bottomEdge.indexForValue(removableStorageOptionsModel, settings.preferRemovableStorage)
@@ -833,7 +834,7 @@ Item {
                 }
             }
             onImageSaved : {
-                if(path && settings.dateStampImages) {
+                if(path && settings.dateStampImages && !main.contentExportMode) {
                     postProcessOperations.addDateStamp(path);
                 }
             }


### PR DESCRIPTION
the exported image might be sent in the middle of altering the image to add date stamp this change should prevent this issue.

also  added notice to translators about that text in the quick option should be short.