### PR TITLE
Added all the supported resolution in the quick menu, not  just the two maximum resolutions 

### DIFF
--- a/CameraApp/advancedcamerasettings.cpp
+++ b/CameraApp/advancedcamerasettings.cpp
@@ -230,6 +230,7 @@ void AdvancedCameraSettings::onSelectedDeviceChanged(int index)
     Q_UNUSED(index);
 
     m_videoSupportedResolutions.clear();
+    m_imageSupportedResolutions.clear();
 
     Q_EMIT resolutionChanged();
     Q_EMIT maximumResolutionChanged();
@@ -270,6 +271,7 @@ void AdvancedCameraSettings::readCapabilities()
     m_videoEncoderControl = videoEncoderControlFromCamera(m_camera);
     m_cameraInfoControl = cameraInfoControlFromCamera(m_camera);
     m_videoSupportedResolutions.clear();
+    m_imageSupportedResolutions.clear();
 
     Q_EMIT resolutionChanged();
     Q_EMIT maximumResolutionChanged();
@@ -356,6 +358,22 @@ float AdvancedCameraSettings::getScreenAspectRatio() const
         ((float)kScreenWidth / (float)kScreenHeight) : ((float)kScreenHeight / (float)kScreenWidth);
 
     return screenAspectRatio;
+}
+
+QStringList AdvancedCameraSettings::imageSupportedResolutions()
+{
+    if (!m_imageEncoderControl) {
+        return QStringList();
+    }
+
+    if(m_imageSupportedResolutions.isEmpty()) {
+        QList<QSize> sizes = m_imageEncoderControl->supportedResolutions(m_imageEncoderControl->imageSettings());
+        Q_FOREACH(QSize size, sizes) {
+            m_imageSupportedResolutions.append(QString("%1x%2").arg(size.width()).arg(size.height()));
+        }
+    }
+
+    return m_imageSupportedResolutions;
 }
 
 QSize AdvancedCameraSettings::fittingResolution() const

--- a/CameraApp/advancedcamerasettings.h
+++ b/CameraApp/advancedcamerasettings.h
@@ -44,6 +44,7 @@ class AdvancedCameraSettings : public QObject
     Q_PROPERTY (QSize maximumResolution READ maximumResolution NOTIFY maximumResolutionChanged)
     Q_PROPERTY (QSize fittingResolution READ fittingResolution NOTIFY fittingResolutionChanged)
     Q_PROPERTY (QStringList videoSupportedResolutions READ videoSupportedResolutions NOTIFY videoSupportedResolutionsChanged)
+    Q_PROPERTY (QStringList imageSupportedResolutions READ imageSupportedResolutions NOTIFY imageSupportedResolutionsChanged)
     Q_PROPERTY (bool hasFlash READ hasFlash NOTIFY hasFlashChanged)
     Q_PROPERTY (bool hdrEnabled READ hdrEnabled WRITE setHdrEnabled NOTIFY hdrEnabledChanged)
     Q_PROPERTY (bool hasHdr READ hasHdr NOTIFY hasHdrChanged)
@@ -60,6 +61,7 @@ public:
     QSize fittingResolution() const;
     float getScreenAspectRatio() const;
     QStringList videoSupportedResolutions();
+    QStringList imageSupportedResolutions();
     bool hasFlash() const;
     bool hasHdr() const;
     bool hdrEnabled() const;
@@ -78,6 +80,7 @@ Q_SIGNALS:
     void hdrEnabledChanged();
     void encodingQualityChanged();
     void videoSupportedResolutionsChanged();
+    void imageSupportedResolutionsChanged();
 
 private Q_SLOTS:
     void onCameraStateChanged();
@@ -108,6 +111,7 @@ private:
     QCameraInfoControl* m_cameraInfoControl;
     bool m_hdrEnabled;
     QStringList m_videoSupportedResolutions;
+    QStringList m_imageSupportedResolutions;
 };
 
 #endif // ADVANCEDCAMERASETTINGS_H

--- a/OptionsOverlay.qml
+++ b/OptionsOverlay.qml
@@ -53,15 +53,21 @@ Item {
         }
     }
 
-    Column {
+    ListView {
         id: optionValueSelector
         objectName: "optionValueSelector"
-        width: childrenRect.width
+
+        height: Math.min( contentHeight, parent.height )
+        snapMode: ListView.SnapToItem
+        clip: true
+        interactive: true
+        flickableDirection: Flickable.VerticalFlick
+        boundsBehavior: Flickable.DragAndOvershootBounds
 
         property OptionButton caller
 
         function toggle(model, callerButton) {
-            if (optionValueSelectorVisible && optionsRepeater.model === model) {
+            if (optionValueSelectorVisible && optionValueSelector.model === model) {
                 hide();
             } else {
                 show(model, callerButton);
@@ -70,9 +76,10 @@ Item {
 
         function show(model, callerButton) {
             optionValueSelector.caller = callerButton;
-            optionsRepeater.model = model;
+            optionValueSelector.model = model;
             alignWith(callerButton);
             optionValueSelectorVisible = true;
+
         }
 
         function hide() {
@@ -81,6 +88,10 @@ Item {
         }
 
         function alignWith(item) {
+            if(model) {
+                forceLayout();
+                width = contentItem.childrenRect.width;
+            }
             // horizontally center optionValueSelector with the center of item
             // if there is enough space to do so, that is as long as optionValueSelector
             // does not get cropped by the edge of the screen
@@ -101,27 +112,24 @@ Item {
         }
 
         visible: opacity !== 0.0
-        onVisibleChanged: if (!visible) optionsRepeater.model = null;
+        onVisibleChanged: if (!visible) model = null;
         opacity: optionValueSelectorVisible ? 1.0 : 0.0
         Behavior on opacity {UbuntuNumberAnimation {duration: UbuntuAnimation.FastDuration}}
 
-        Repeater {
-            id: optionsRepeater
+        delegate: OptionValueButton {
+            anchors.left: optionValueSelector.left
+            columnWidth: optionValueSelector.width
 
-            delegate: OptionValueButton {
-                anchors.left: optionValueSelector.left
-                columnWidth: optionValueSelector.childrenRect.width
+            label: (model && model.label) ? i18n.tr(model.label) : ""
+            iconName: (model && model.icon) ? model.icon : ""
+            selected: optionValueSelector.model.selectedIndex == index
 
-                label: (model && model.label) ? i18n.tr(model.label) : ""
-                iconName: (model && model.icon) ? model.icon : ""
-                selected: optionsRepeater.model.selectedIndex == index
-                isLast: index === optionsRepeater.count - 1
-                onClicked: {
-                    if (optionsRepeater.model.setSettingProperty) {
-                        optionsRepeater.model.setSettingProperty(optionsRepeater.model.get(index).value);
-                    } else {
-                        settings[optionsRepeater.model.settingsProperty] = optionsRepeater.model.get(index).value;
-                    }
+            isLast: index === optionValueSelector.count - 1
+            onClicked: {
+                if (optionValueSelector.model.setSettingProperty) {
+                    optionValueSelector.model.setSettingProperty(optionValueSelector.model.get(index).value);
+                } else {
+                    settings[optionValueSelector.model.settingsProperty] = optionValueSelector.model.get(index).value;
                 }
             }
         }
@@ -131,7 +139,6 @@ Item {
         id:advancedOptionsToggle
         anchors.right: optionsOverlay.right
         anchors.bottom: optionsOverlay.bottom
-        columnWidth: optionValueSelector.childrenRect.width
         iconName:  "settings"
         isLast: true
         onClicked: {

--- a/OptionsOverlay.qml
+++ b/OptionsOverlay.qml
@@ -15,6 +15,7 @@
  */
 
 import QtQuick 2.4
+import QtQuick.Window 2.2
 import Ubuntu.Components 1.3
 
 Item {
@@ -57,7 +58,7 @@ Item {
         id: optionValueSelector
         objectName: "optionValueSelector"
 
-        height: Math.min( contentHeight, parent.height )
+        height: Math.min( contentHeight, Screen.height / 2 )
         snapMode: ListView.SnapToItem
         clip: true
         interactive: true
@@ -79,6 +80,7 @@ Item {
             optionValueSelector.model = model;
             alignWith(callerButton);
             optionValueSelectorVisible = true;
+            positionViewAtIndex(model.selectedIndex, ListView.Contain);
 
         }
 
@@ -116,6 +118,14 @@ Item {
         opacity: optionValueSelectorVisible ? 1.0 : 0.0
         Behavior on opacity {UbuntuNumberAnimation {duration: UbuntuAnimation.FastDuration}}
 
+        headerPositioning:  ListView.OverlayHeader
+        header: Icon {
+            anchors.horizontalCenter: parent.horizontalCenter
+            height: units.gu(3)
+            visible: !optionValueSelector.atYBeginning
+            name:"go-up"
+        }
+
         delegate: OptionValueButton {
             anchors.left: optionValueSelector.left
             columnWidth: optionValueSelector.width
@@ -132,6 +142,13 @@ Item {
                     settings[optionValueSelector.model.settingsProperty] = optionValueSelector.model.get(index).value;
                 }
             }
+        }
+        footerPositioning: ListView.OverlayFooter
+        footer: Icon {
+            anchors.horizontalCenter: parent.horizontalCenter
+            height: units.gu(3)
+            visible: !optionValueSelector.atYEnd
+            name:"go-down"
         }
     }
 

--- a/ViewFinderOverlay.qml
+++ b/ViewFinderOverlay.qml
@@ -205,8 +205,16 @@ Item {
         // Clear and refill photoResolutionOptionsModel with available resolutions
         photoResolutionOptionsModel.clear();
 
+
+        //Change to Size object and sort the resolutions by megapixel ( in reverse order so it goes from top high to  bottom low )
+        var sortedResolutions = [];
         for(var i in camera.advanced.imageSupportedResolutions) {
-            var res = stringToSize(camera.advanced.imageSupportedResolutions[i]);
+            sortedResolutions.push( stringToSize(camera.advanced.imageSupportedResolutions[i]) );
+        }
+        sortedResolutions.sort(function(a, b) { return sizeToMegapixels(b) - sizeToMegapixels(a) });
+
+        for(var i in sortedResolutions) {
+            var res = sortedResolutions[i];
             photoResolutionOptionsModel.insert(i,{"icon": "",
                                                    "label": "%1 (%2MP)".arg(sizeToAspectRatio(res))
                                                                        .arg(sizeToMegapixels(res)),

--- a/ViewFinderOverlay.qml
+++ b/ViewFinderOverlay.qml
@@ -54,6 +54,7 @@ Item {
         property string videoResolution: "1920x1080"
         property bool playShutterSound: true
         property var photoResolutions
+        property var photoResolution : "1920x1080"
         property bool dateStampImages: false
 
         Component.onCompleted: if (!photoResolutions) photoResolutions = {}
@@ -82,7 +83,7 @@ Item {
     }
 
     Binding {
-        target: camera.advanced
+        target: camera.imageCapture.resolution
         property: "encodingQuality"
         value: settings.encodingQuality
     }
@@ -201,24 +202,12 @@ Item {
         // Clear and refill photoResolutionOptionsModel with available resolutions
         photoResolutionOptionsModel.clear();
 
-        var optionMaximum = {"icon": "",
-                             "label": "%1 (%2MP)".arg(sizeToAspectRatio(camera.advanced.maximumResolution))
-                                                 .arg(sizeToMegapixels(camera.advanced.maximumResolution)),
-                             "value": sizeToString(camera.advanced.maximumResolution)};
-
-        var optionFitting = {"icon": "",
-                             "label": "%1 (%2MP)".arg(sizeToAspectRatio(camera.advanced.fittingResolution))
-                                                 .arg(sizeToMegapixels(camera.advanced.fittingResolution)),
-                             "value": sizeToString(camera.advanced.fittingResolution)};
-
-        photoResolutionOptionsModel.insert(0, optionMaximum);
-
-        // Only show optionFitting if it's greater than 50% of the maximum available resolution
-        var fittingSize = camera.advanced.fittingResolution.width * camera.advanced.fittingResolution.height;
-        var maximumSize = camera.advanced.maximumResolution.width * camera.advanced.maximumResolution.height;
-        if (camera.advanced.fittingResolution != camera.advanced.maximumResolution &&
-            fittingSize / maximumSize >= 0.5) {
-            photoResolutionOptionsModel.insert(1, optionFitting);
+        for(var i in camera.advanced.imageSupportedResolutions) {
+            var res = stringToSize(camera.advanced.imageSupportedResolutions[i]);
+            photoResolutionOptionsModel.insert(i,{"icon": "",
+                                                   "label": "%1 (%2MP)".arg(sizeToAspectRatio(res))
+                                                                       .arg(sizeToMegapixels(res)),
+                                                   "value": sizeToString(res)});
         }
 
         // If resolution setting is not supported select the resolution automatically
@@ -226,6 +215,7 @@ Item {
         if (!isResolutionAnOption(photoResolution)) {
             setPhotoResolution(getAutomaticResolution());
         }
+
     }
 
     function setPhotoResolution(resolution) {
@@ -577,7 +567,7 @@ Item {
                     }
 
                     property string icon: ""
-                    property string label: sizeToAspectRatio(stringToSize(settings.photoResolutions[camera.deviceId]))
+                    property string label: "%1MP)".arg(sizeToMegapixels(stringToSize(settings.photoResolutions[camera.deviceId]))
                     property bool isToggle: false
                     property int selectedIndex: bottomEdge.indexForValue(photoResolutionOptionsModel, settings.photoResolutions[camera.deviceId])
                     property bool available: true

--- a/ViewFinderOverlay.qml
+++ b/ViewFinderOverlay.qml
@@ -567,7 +567,7 @@ Item {
                     }
 
                     property string icon: ""
-                    property string label: "%1MP)".arg(sizeToMegapixels(stringToSize(settings.photoResolutions[camera.deviceId]))
+                    property string label: "%1mp".arg(sizeToMegapixels(stringToSize(settings.photoResolutions[camera.deviceId])))
                     property bool isToggle: false
                     property int selectedIndex: bottomEdge.indexForValue(photoResolutionOptionsModel, settings.photoResolutions[camera.deviceId])
                     property bool available: true

--- a/ViewFinderOverlay.qml
+++ b/ViewFinderOverlay.qml
@@ -54,7 +54,6 @@ Item {
         property string videoResolution: "1920x1080"
         property bool playShutterSound: true
         property var photoResolutions
-        property var photoResolution : "1920x1080"
         property bool dateStampImages: false
 
         Component.onCompleted: if (!photoResolutions) photoResolutions = {}

--- a/ViewFinderOverlay.qml
+++ b/ViewFinderOverlay.qml
@@ -171,6 +171,10 @@ Item {
         return parseFloat(megapixels.toFixed(1))
     }
 
+    function trimNumberToFit(numberStr, digits) {
+        return (""+numberStr).substr(0,digits).replace(/\.$/,"");
+    }
+
     function updateVideoResolutionOptions() {
         // Clear and refill videoResolutionOptionsModel with available resolutions
         // Try to only display well known resolutions: 1080p, 720p and 480p
@@ -567,7 +571,7 @@ Item {
                     }
 
                     property string icon: ""
-                    property string label: "%1mp".arg(sizeToMegapixels(stringToSize(settings.photoResolutions[camera.deviceId])))
+                    property string label: "%1MP".arg(trimNumberToFit(sizeToMegapixels(stringToSize(settings.photoResolutions[camera.deviceId])),3))
                     property bool isToggle: false
                     property int selectedIndex: bottomEdge.indexForValue(photoResolutionOptionsModel, settings.photoResolutions[camera.deviceId])
                     property bool available: true


### PR DESCRIPTION
- added backend support to get the supported resolutions from the camera ( issue #13 )
- modifyed the UI to display the megapixels instead of the aspect ratio (as you can see the aspect ratio in the optin meny and by the size of the viewfinder)