### PR TITLE
Photo roll UI improvments

### DIFF
--- a/GalleryView.qml
+++ b/GalleryView.qml
@@ -115,6 +115,7 @@ Item {
         // FIXME: it would be better to use the standard header from the toolkit
         GalleryViewHeader {
             id: header
+            z:1
             actions: currentView.actions
             gridMode: galleryView.gridMode
             validationVisible: main.contentExportMode && model.selectedFiles.length > 0 && galleryView.gridMode

--- a/GalleryView.qml
+++ b/GalleryView.qml
@@ -95,6 +95,7 @@ Item {
             inSelectionMode: main.contentExportMode || galleryView.userSelectionMode
             onPhotoClicked: {
                 slideshowView.showPhotoAtIndex(index);
+                photogridView.showPhotoAtIndex(index);
                 galleryView.inTransition = true;
                 galleryView.gridMode = false;
             }

--- a/GalleryView.qml
+++ b/GalleryView.qml
@@ -26,6 +26,7 @@ Item {
 
     signal exit
     property bool inView
+    property bool inTransition: false
     property bool touchAcquired: slideshowView.touchAcquired
     property bool userSelectionMode: false
     property Item currentView: state == "GRID" ? photogridView : slideshowView
@@ -74,7 +75,7 @@ Item {
             anchors.fill: parent
             model: galleryView.model
             visible: opacity != 0.0
-            inView: galleryView.inView && galleryView.currentView == slideshowView
+            inView: galleryView.inView &&  ( galleryView.currentView == slideshowView || galleryView.inTransition )
             focus: inView
             inSelectionMode: main.contentExportMode || galleryView.userSelectionMode
             onToggleSelection: model.toggleSelected(currentIndex)
@@ -88,11 +89,12 @@ Item {
             userSelectionMode: galleryView.userSelectionMode
             model: galleryView.model
             visible: opacity != 0.0
-            inView: galleryView.inView && galleryView.currentView == photogridView
+            inView: galleryView.inView && ( galleryView.currentView == photogridView || galleryView.inTransition )
             focus: inView
             inSelectionMode: main.contentExportMode || galleryView.userSelectionMode
             onPhotoClicked: {
                 slideshowView.showPhotoAtIndex(index);
+                galleryView.inTransition = true;
                 galleryView.gridMode = false;
             }
             onPhotoPressAndHold: {
@@ -133,7 +135,7 @@ Item {
                     // position grid view so that the current photo in slideshow view is visible
                     photogridView.showPhotoAtIndex(slideshowView.currentIndex);
                 }
-
+                galleryView.inTransition = true;
                 galleryView.gridMode = !galleryView.gridMode
             }
             onToggleSelectAll: {
@@ -256,6 +258,7 @@ Item {
     }
 
     state: galleryView.gridMode ? "GRID" : "SLIDESHOW"
+    onStateChanged: inTransition = true;
     states: [
         State {
             name: "SLIDESHOW"
@@ -274,7 +277,7 @@ Item {
             name: "GRID"
             PropertyChanges {
                 target: slideshowView
-                scale: 1.4
+                scale: 0.4
                 opacity: 0.0
             }
             PropertyChanges {
@@ -287,8 +290,12 @@ Item {
 
     transitions: [
         Transition {
+            id:galleryViewTransition
             to: "*"
-            UbuntuNumberAnimation { properties: "scale,opacity"; duration: UbuntuAnimation.SnapDuration }
+            UbuntuNumberAnimation { properties: "scale,opacity"; duration: UbuntuAnimation.BriskDuration }
+            onRunningChanged: {
+                inTransition = running;
+            }
         }
     ]
 }

--- a/GalleryView.qml
+++ b/GalleryView.qml
@@ -80,6 +80,7 @@ Item {
             inSelectionMode: main.contentExportMode || galleryView.userSelectionMode
             onToggleSelection: model.toggleSelected(currentIndex)
             onToggleHeader: header.toggle();
+            onBottomEdgeCommit : galleryView.gridMode = true;
         }
 
         PhotogridView {

--- a/GalleryView.qml
+++ b/GalleryView.qml
@@ -121,6 +121,7 @@ Item {
             gridMode: galleryView.gridMode
             validationVisible: main.contentExportMode && model.selectedFiles.length > 0 && galleryView.gridMode
             userSelectionMode: galleryView.userSelectionMode
+            backgroundItem: inTransition ? null : galleryView.currentView
             onExit: {
                 if ((main.contentExportMode || userSelectionMode) && !galleryView.gridMode) {
                     galleryView.gridMode = true;

--- a/GalleryView.qml
+++ b/GalleryView.qml
@@ -80,7 +80,7 @@ Item {
             inSelectionMode: main.contentExportMode || galleryView.userSelectionMode
             onToggleSelection: model.toggleSelected(currentIndex)
             onToggleHeader: header.toggle();
-            onBottomEdgeCommit : galleryView.gridMode = true;
+            onBottomEdgeCommit : { galleryView.gridMode = true; header.show();}
         }
 
         PhotogridView {
@@ -121,7 +121,6 @@ Item {
             gridMode: galleryView.gridMode
             validationVisible: main.contentExportMode && model.selectedFiles.length > 0 && galleryView.gridMode
             userSelectionMode: galleryView.userSelectionMode
-            backgroundItem: inTransition ? null : galleryView.currentView
             onExit: {
                 if ((main.contentExportMode || userSelectionMode) && !galleryView.gridMode) {
                     galleryView.gridMode = true;

--- a/GalleryViewHeader.qml
+++ b/GalleryViewHeader.qml
@@ -17,6 +17,7 @@
 import QtQuick 2.4
 import Ubuntu.Components 1.3
 import QtQuick.Layouts 1.1
+import QtGraphicalEffects 1.0
 
 Item {
     id: header
@@ -38,6 +39,7 @@ Item {
     property bool editMode: false
     property bool validationVisible
     property bool userSelectionMode: false
+    property var backgroundItem: null
     signal exit
     signal exitEditor
     signal toggleViews
@@ -55,10 +57,15 @@ Item {
         shown = !shown;
     }
 
+    OverlayBlur {
+        backgroundItem : header.backgroundItem
+        overlayItem: headerBkRect
+    }
+
     Rectangle {
+        id:headerBkRect
         anchors.fill: parent
-        color: "black"
-        opacity: 0.6
+        color: Qt.rgba(0,0,0,0.6)
     }
 
     RowLayout {

--- a/GalleryViewHeader.qml
+++ b/GalleryViewHeader.qml
@@ -39,7 +39,6 @@ Item {
     property bool editMode: false
     property bool validationVisible
     property bool userSelectionMode: false
-    property var backgroundItem: null
     signal exit
     signal exitEditor
     signal toggleViews
@@ -55,11 +54,6 @@ Item {
             actionsDrawer.close();
         }
         shown = !shown;
-    }
-
-    OverlayBlur {
-        backgroundItem : header.backgroundItem
-        overlayItem: headerBkRect
     }
 
     Rectangle {

--- a/GalleryViewHeader.qml
+++ b/GalleryViewHeader.qml
@@ -88,19 +88,6 @@ Item {
         }
 
         IconButton {
-            objectName: "galleryLink"
-            anchors {
-                top: parent.top
-                bottom: parent.bottom
-            }
-            width: units.gu(8)
-            visible: !editMode && !userSelectionMode && gridMode
-            iconName: "gallery-app-symbolic"
-            iconColor: "white"
-            onClicked: Qt.openUrlExternally("appid://com.ubuntu.gallery/gallery/current-user-version")
-        }
-
-        IconButton {
             objectName: "viewToggleButton"
             anchors {
                 top: parent.top

--- a/GalleryViewHeader.qml
+++ b/GalleryViewHeader.qml
@@ -93,7 +93,7 @@ Item {
                 bottom: parent.bottom
             }
             width: units.gu(8)
-            visible: !editMode && !userSelectionMode
+            visible: !editMode && !userSelectionMode && gridMode
             iconName: "gallery-app-symbolic"
             iconColor: "white"
             onClicked: Qt.openUrlExternally("appid://com.ubuntu.gallery/gallery/current-user-version")
@@ -127,7 +127,7 @@ Item {
                 top: parent.top
                 bottom: parent.bottom
             }
-            action: actionsDrawer.actions[0]
+            action: actionsDrawer.actions[0] ? actionsDrawer.actions[0] : null
             visible: actionsDrawer.actions.length == 1 && !editMode
             onTriggered: if (action) action.triggered()
         }

--- a/OverlayBlur.qml
+++ b/OverlayBlur.qml
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2014 Canonical, Ltd.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import QtQuick 2.4
+import Ubuntu.Components 1.3
+import QtGraphicalEffects 1.0
+
+FastBlur {
+    id: overlayBlurEffect
+    property var overlayItem
+    property var backgroundItem
+    property int offestX: 0
+    property int offestY: 0
+
+    anchors.fill: overlayItem
+
+    radius: units.gu(2)
+    source:  ShaderEffectSource {
+        clip: true
+        sourceItem: backgroundItem
+        sourceRect: Qt.rect( overlayItem.mapToItem(backgroundItem).x+offestX,
+                             overlayItem.mapToItem(backgroundItem).y+offestY,
+                             overlayItem.width,
+                             overlayItem.height)
+    }
+
+
+}

--- a/OverlayBlur.qml
+++ b/OverlayBlur.qml
@@ -22,8 +22,6 @@ FastBlur {
     id: overlayBlurEffect
     property var overlayItem
     property var backgroundItem
-    property int offestX: 0
-    property int offestY: 0
 
     anchors.fill: overlayItem
 
@@ -31,11 +29,10 @@ FastBlur {
     source:  ShaderEffectSource {
         clip: true
         sourceItem: backgroundItem
-        sourceRect: Qt.rect( overlayItem.mapToItem(backgroundItem).x+offestX,
-                             overlayItem.mapToItem(backgroundItem).y+offestY,
+        sourceRect: Qt.rect( overlayItem.mapToItem(backgroundItem).x,
+                             overlayItem.mapToItem(backgroundItem).y,
                              overlayItem.width,
-                             overlayItem.height)
+                             overlayItem.height )
+        recursive: true
     }
-
-
 }

--- a/PhotogridView.qml
+++ b/PhotogridView.qml
@@ -170,7 +170,7 @@ FocusScope {
                     }
 
                     asynchronous: true
-                    cache: status == Image.Ready
+                    cache: true
                     // The thumbnailer does not seem to check when an image has been changed on disk,
                     // so we use this hack to force it to check and refresh if necessary.
                     source: photogridView.inView ? "image://thumbnailer/" + fileURL.toString() + "?at=" + Date.now() : ""

--- a/PhotogridView.qml
+++ b/PhotogridView.qml
@@ -19,6 +19,7 @@ import Ubuntu.Components 1.3
 import Ubuntu.Components.Popups 1.3
 import Ubuntu.Thumbnailer 0.1
 import Ubuntu.Content 1.3
+import Qt.labs.settings 1.0
 import CameraApp 0.1
 import "MimeTypeMapper.js" as MimeTypeMapper
 
@@ -83,135 +84,173 @@ FocusScope {
     function exit() {
     }
 
-    ResponsiveGridView {
-        id: gridView
+    Settings {
+        id:galleryGridViewSettings
+        property var delegateWidth: gridView.baseDelegateWidth
+        property var delegateHeight: gridView.baseDelegateHeight
+        property real currentScale: 1
+    }
+
+    PinchArea {
+        id:galleryViewPinch
         anchors.fill: parent
-        // FIXME: prevent the header from overlapping the beginning of the grid
-        // when Qt 5.3 is landed, use property 'displayMarginBeginning' instead
-        // cf. http://qt-project.org/doc/qt-5/qml-qtquick-gridview.html#displayMarginBeginning-prop
-        header: Item {
-            width: gridView.width
-            height: headerHeight
+
+        property real currentScale: galleryGridViewSettings.currentScale
+        pinch.dragAxis: Pinch.NoDrag
+        pinch.minimumScale: 0.5
+        pinch.maximumScale: 1.5
+        //FIXME  This is a a workaround to that remember the scale between pinches
+        pinch.target: Item {
+          width: galleryGridViewSettings.delegateWidth
+          height: galleryGridViewSettings.delegateHeight
+          scale:galleryGridViewSettings.currentScale
+          visible:false
         }
 
-        Component.onCompleted: {
-            // FIXME: workaround for qtubuntu not returning values depending on the grid unit definition
-            // for Flickable.maximumFlickVelocity and Flickable.flickDeceleration
-            var scaleFactor = units.gridUnit / 8;
-            maximumFlickVelocity = maximumFlickVelocity * scaleFactor;
-            flickDeceleration = flickDeceleration * scaleFactor;
+
+        onPinchUpdated: {
+            if( pinch.scale ) {
+                galleryGridViewSettings.currentScale = Math.min(2,Math.max(0.33,galleryViewPinch.pinch.target.scale))  ;
+                galleryGridViewSettings.delegateHeight = Math.floor(gridView.baseDelegateHeight * currentScale);
+                galleryGridViewSettings.delegateWidth =  Math.floor(gridView.baseDelegateWidth * currentScale);
+            }
         }
 
-        minimumHorizontalSpacing: units.dp(2)
-        maximumNumberOfColumns: 100
-        delegateWidth: units.gu(13)
-        delegateHeight: units.gu(13)
-
-        model: photogridView.model
-        delegate: Item {
-            id: cellDelegate
-            objectName: "mediaItem" + index
-            
-            width: gridView.cellWidth
-            height: gridView.cellHeight
-
-            property bool isVideo: MimeTypeMapper.mimeTypeToContentType(fileType) === ContentType.Videos
-
-            Image {
-                id: thumbnail
-                property real margin: units.dp(2)
-                anchors {
-                    top: parent.top
-                    topMargin: index < photogridView.columns ? 0 : margin/2
-                    bottom: parent.bottom
-                    bottomMargin: margin/2
-                    left: parent.left
-                    leftMargin: index % photogridView.columns == 0 ? 0 : margin/2
-                    right: parent.right
-                    rightMargin: index % photogridView.columns == photogridView.columns - 1 ? 0 : margin/2
-                }
-                
-                asynchronous: true
-                cache: false
-                // The thumbnailer does not seem to check when an image has been changed on disk,
-                // so we use this hack to force it to check and refresh if necessary.
-                source: photogridView.inView ? "image://thumbnailer/" + fileURL.toString() + "?at=" + Date.now() : ""
-                sourceSize {
-                    width: width
-                    height: height
-                }
-                fillMode: Image.PreserveAspectCrop
-                opacity: status == Image.Ready ? 1.0 : 0.0
-                Behavior on opacity { UbuntuNumberAnimation {duration: UbuntuAnimation.FastDuration} }
+        ResponsiveGridView {
+            id: gridView
+            anchors.fill: parent
+            // FIXME: prevent the header from overlapping the beginning of the grid
+            // when Qt 5.3 is landed, use property 'displayMarginBeginning' instead
+            // cf. http://qt-project.org/doc/qt-5/qml-qtquick-gridview.html#displayMarginBeginning-prop
+            header: Item {
+                width: gridView.width
+                height: headerHeight
             }
 
-            Icon {
-                width: units.gu(3)
-                height: units.gu(3)
-                anchors.centerIn: parent
-                name: "media-playback-start"
-                color: "white"
-                opacity: 0.8
-                visible: isVideo
-                asynchronous: true
+            property var baseDelegateWidth: units.gu(13)
+            property var baseDelegateHeight: units.gu(13)
+
+            Component.onCompleted: {
+                // FIXME: workaround for qtubuntu not returning values depending on the grid unit definition
+                // for Flickable.maximumFlickVelocity and Flickable.flickDeceleration
+                var scaleFactor = units.gridUnit / 8;
+                maximumFlickVelocity = maximumFlickVelocity * scaleFactor;
+                flickDeceleration = flickDeceleration * scaleFactor;
             }
 
-            Icon {
-                objectName: "thumbnailLoadingErrorIcon"
-                anchors.centerIn: parent
-                width: units.gu(6)
-                height: width
-                name: cellDelegate.isVideo ? "stock_video" : "stock_image"
-                color: "white"
-                opacity: thumbnail.status == Image.Error ? 1.0 : 0.0
-                asynchronous: true
-             }
+            minimumHorizontalSpacing: units.dp(2)
+            maximumNumberOfColumns: 100
+            delegateWidth: galleryGridViewSettings.delegateWidth
+            delegateHeight: galleryGridViewSettings.delegateHeight
+            StateSaver.properties:"delegateWidth,delegateHeight"
 
-            MouseArea {
-                anchors.fill: parent
-                onClicked: photogridView.photoClicked(index)
-                onPressAndHold: photogridView.photoPressAndHold(index)
-            }
+            model: photogridView.model
+            delegate: Item {
+                z:10
+                id: cellDelegate
+                objectName: "mediaItem" + index
 
-            Rectangle {
-                anchors {
-                    top: parent.top
-                    right: parent.right
-                    topMargin: units.gu(0.5)
-                    rightMargin: units.gu(0.5)
+                width: gridView.cellWidth
+                height: gridView.cellHeight
+
+                property bool isVideo: MimeTypeMapper.mimeTypeToContentType(fileType) === ContentType.Videos
+
+                Image {
+                    id: thumbnail
+                    property real margin: units.dp(2)
+                    anchors {
+                        top: parent.top
+                        topMargin: index < photogridView.columns ? 0 : margin/2
+                        bottom: parent.bottom
+                        bottomMargin: margin/2
+                        left: parent.left
+                        leftMargin: index % photogridView.columns == 0 ? 0 : margin/2
+                        right: parent.right
+                        rightMargin: index % photogridView.columns == photogridView.columns - 1 ? 0 : margin/2
+                    }
+
+                    asynchronous: true
+                    cache: true
+                    // The thumbnailer does not seem to check when an image has been changed on disk,
+                    // so we use this hack to force it to check and refresh if necessary.
+                    source: photogridView.inView ? "image://thumbnailer/" + fileURL.toString() + "?at=" + Date.now() : ""
+                    sourceSize {
+                        width: gridView.baseDelegateWidth
+                        height: gridView.baseDelegateHeight
+                    }
+                    fillMode: Image.PreserveAspectCrop
+                    opacity: status == Image.Ready ? 1.0 : 0.0
+                    Behavior on opacity { UbuntuNumberAnimation {duration: UbuntuAnimation.FastDuration} }
                 }
-                width: units.gu(4)
-                height: units.gu(4)
-                color: selected ? UbuntuColors.orange : UbuntuColors.coolGrey
-                radius: 10
-                opacity: selected ? 0.8 : 0.6
-                visible: inSelectionMode
 
                 Icon {
-                    objectName: "mediaItemCheckBox"
+                    width: units.gu(3)
+                    height: units.gu(3)
                     anchors.centerIn: parent
-                    width: parent.width * 0.8
-                    height: parent.height * 0.8
-                    name: "ok"
+                    name: "media-playback-start"
                     color: "white"
-                    visible: selected
+                    opacity: 0.8
+                    visible: isVideo
                     asynchronous: true
                 }
 
-            }
+                Icon {
+                    objectName: "thumbnailLoadingErrorIcon"
+                    anchors.centerIn: parent
+                    width: units.gu(6)
+                    height: width
+                    name: cellDelegate.isVideo ? "stock_video" : "stock_image"
+                    color: "white"
+                    opacity: thumbnail.status == Image.Error ? 1.0 : 0.0
+                    asynchronous: true
+                 }
 
-            MouseArea {
-                anchors {
-                    top: parent.top
-                    right: parent.right
+                MouseArea {
+                    anchors.fill: parent
+                    onClicked: photogridView.photoClicked(index)
+                    onPressAndHold: photogridView.photoPressAndHold(index)
                 }
-                width: parent.width * 0.5
-                height: parent.height * 0.5
-                enabled: inSelectionMode
- 
-                onClicked: {
-                    mouse.accepted = true;
-                    photogridView.photoSelectionAreaClicked(index)
+
+                Rectangle {
+                    anchors {
+                        top: parent.top
+                        right: parent.right
+                        topMargin: units.gu(0.5)
+                        rightMargin: units.gu(0.5)
+                    }
+                    width: units.gu(4)
+                    height: units.gu(4)
+                    color: selected ? UbuntuColors.orange : UbuntuColors.coolGrey
+                    radius: 10
+                    opacity: selected ? 0.8 : 0.6
+                    visible: inSelectionMode
+
+                    Icon {
+                        objectName: "mediaItemCheckBox"
+                        anchors.centerIn: parent
+                        width: parent.width * 0.8
+                        height: parent.height * 0.8
+                        name: "ok"
+                        color: "white"
+                        visible: selected
+                        asynchronous: true
+                    }
+
+                }
+
+                MouseArea {
+                    anchors {
+                        top: parent.top
+                        right: parent.right
+                    }
+                    width: parent.width * 0.5
+                    height: parent.height * 0.5
+                    enabled: inSelectionMode
+
+                    onClicked: {
+                        mouse.accepted = true;
+                        photogridView.photoSelectionAreaClicked(index)
+                    }
                 }
             }
         }

--- a/PhotogridView.qml
+++ b/PhotogridView.qml
@@ -36,7 +36,7 @@ FocusScope {
     property bool inView
     property bool inSelectionMode
     property bool userSelectionMode: false
-    property var actions: userSelectionMode ? userSelectionActions : null
+    property var actions: userSelectionMode ? userSelectionActions : regularModeActions
     property list<Action> userSelectionActions: [
         Action {
             text: i18n.tr("Share")
@@ -62,6 +62,15 @@ FocusScope {
                 }
             }
         }
+    ]
+
+    property list<Action> regularModeActions: [
+            Action {
+                text: i18n.tr("Gallery")
+                objectName: "galleryLink"
+                iconName: "gallery-app-symbolic"
+                onTriggered: { Qt.openUrlExternally("appid://com.ubuntu.gallery/gallery/current-user-version") }
+            }
     ]
 
     function selectionContainsMixedMedia() {

--- a/PhotogridView.qml
+++ b/PhotogridView.qml
@@ -99,14 +99,13 @@ FocusScope {
         pinch.dragAxis: Pinch.NoDrag
         pinch.minimumScale: 0.5
         pinch.maximumScale: 1.5
-        //FIXME  This is a a workaround to that remember the scale between pinches
+        //FIXME  This is a a workaround that remember the scale between pinches
         pinch.target: Item {
           width: galleryGridViewSettings.delegateWidth
           height: galleryGridViewSettings.delegateHeight
           scale:galleryGridViewSettings.currentScale
           visible:false
         }
-
 
         onPinchUpdated: {
             if( pinch.scale ) {
@@ -152,6 +151,9 @@ FocusScope {
 
                 width: gridView.cellWidth
                 height: gridView.cellHeight
+
+                Behavior on height { UbuntuNumberAnimation {} }
+                Behavior on width { UbuntuNumberAnimation {} }
 
                 property bool isVideo: MimeTypeMapper.mimeTypeToContentType(fileType) === ContentType.Videos
 

--- a/PhotogridView.qml
+++ b/PhotogridView.qml
@@ -170,7 +170,7 @@ FocusScope {
                     }
 
                     asynchronous: true
-                    cache: true
+                    cache: status == Image.Ready
                     // The thumbnailer does not seem to check when an image has been changed on disk,
                     // so we use this hack to force it to check and refresh if necessary.
                     source: photogridView.inView ? "image://thumbnailer/" + fileURL.toString() + "?at=" + Date.now() : ""

--- a/ResponsiveGridView.qml
+++ b/ResponsiveGridView.qml
@@ -75,7 +75,7 @@ Item {
         clip: parent.height != totalContentHeight
 
         function pixelToGU(value) {
-            return Math.floor(value / units.gu(1));
+            return (value / units.gu(1));
         }
 
         function spacingForColumns(columns) {

--- a/ResponsiveGridView.qml
+++ b/ResponsiveGridView.qml
@@ -61,8 +61,18 @@ Item {
     }
 
     function positionViewAtIndex(index, mode) {
+        anim.running=false;
+        anim.from= gridView.contentY;
         gridView.positionViewAtIndex(index, mode);
+        anim.to= gridView.contentY;
+        anim.running=true;
     }
+
+    function indexAt(x,y) {
+        return gridView.indexAt(x,y);
+    }
+
+    NumberAnimation { id: anim; target: gridView; property: "contentY"; }
 
     GridView {
         id: gridView

--- a/SlideshowView.qml
+++ b/SlideshowView.qml
@@ -414,20 +414,20 @@ FocusScope {
         visible: enabled
         height:units.gu(8)
         hint.text: i18n.tr("Back to Photo roll");
-        hint.deactivateTimeout: UbuntuAnimation.SlowDuration
         hint.iconName: "go-up"
         hint.visible:enabled
 
         contentComponent: Page {
             opacity: photoBottomEdge.dragProgress
             header: PageHeader { opacity: 0 }
-
             Rectangle {
                 id:photoBottomEdgeRect
                 width:photoBottomEdge.width
                 height:photoBottomEdge.height
                 color: Qt.rgba(0,0,0,0.6)
             }
+
+
             Icon {
                 id:bottomEdgeGoUpIcon
                 height:units.gu(3)
@@ -441,9 +441,9 @@ FocusScope {
                 anchors.horizontalCenter:parent.horizontalCenter
                 verticalAlignment: Text.AlignVCenter
                 height:photoBottomEdge.height
-                text: i18n.tr("Back to Photo roll");
+                text: photoBottomEdge.hint.text
                 color:"white"
-                font.pointSize: units.gu(3)
+                fontSize: "x-large"
             }
         }
 

--- a/SlideshowView.qml
+++ b/SlideshowView.qml
@@ -412,7 +412,7 @@ FocusScope {
         id: photoBottomEdge
         enabled: !editor.active
         visible: enabled
-        height:parent.height / 2;
+        height:units.gu(8)
         hint.text: i18n.tr("Back to Photo roll");
         hint.deactivateTimeout: UbuntuAnimation.SlowDuration
         hint.iconName: "go-up"
@@ -422,15 +422,28 @@ FocusScope {
             opacity: photoBottomEdge.dragProgress
             header: PageHeader { opacity: 0 }
 
-             Rectangle {
+            Rectangle {
+                id:photoBottomEdgeRect
                 width:photoBottomEdge.width
                 height:photoBottomEdge.height
-                color: Qt.rgba(0,0,0,0.2)
-                layer.enabled: true
-                layer.effect: FastBlur {
-                    radius: units.gu(2) * photoBottomEdge.dragProgress
-                    transparentBorder: true
-                }
+                color: Qt.rgba(0,0,0,0.6)
+            }
+            Icon {
+                id:bottomEdgeGoUpIcon
+                height:units.gu(3)
+                width:units.gu(3)
+                name:"go-up"
+                color: "white"
+                anchors.top:parent.top
+                anchors.horizontalCenter:parent.horizontalCenter
+            }
+            Label {
+                anchors.horizontalCenter:parent.horizontalCenter
+                verticalAlignment: Text.AlignVCenter
+                height:photoBottomEdge.height
+                text: i18n.tr("Back to Photo roll");
+                color:"white"
+                font.pointSize: units.gu(3)
             }
         }
 

--- a/SlideshowView.qml
+++ b/SlideshowView.qml
@@ -50,6 +50,13 @@ FocusScope {
 
     property list<Action> slideShowActions: [
         Action {
+            text: i18n.tr("Gallery")
+            objectName: "galleryLink"
+            enabled: !editor.active
+            iconName: "gallery-app-symbolic"
+            onTriggered: { Qt.openUrlExternally("appid://com.ubuntu.gallery/gallery/current-user-version") }
+        },
+        Action {
             text: i18n.tr("Share")
             iconName: "share"
             onTriggered: {

--- a/manifest.json.in
+++ b/manifest.json.in
@@ -10,7 +10,7 @@
         }
     },
     "icon": "@CAMERA_ICON@",
-    "maintainer": "Ubuntu Developers <ubuntu-devel-discuss@lists.ubuntu.com>",
+    "maintainer": "UBports <community@ubports.com>",
     "name": "com.ubuntu.camera",
     "title": "Camera",
     "version": "3.0.0.@REVNO@",
@@ -21,7 +21,10 @@
     "x-test": {
         "autopilot": {
             "autopilot_module": "@AUTOPILOT_DIR@",
-            "depends": ["python3-wand", "python3-mediainfodll"]
+            "depends": [
+                "python3-wand",
+                "python3-mediainfodll"
+            ]
         }
     }
 }


### PR DESCRIPTION
Improved the Photo roll UI a little : 
- Implemented Camera App #35 Adjustable thumbnails in photo roll.
- Improved the grid to single photo transition
- Added bottom edge action to go back from single photo to photo roll
- Blurred the background of the header
- Removed the gallery app link in single photo to avoid confusion.

Also changed the maintainer to point to Ubports.